### PR TITLE
Experimental tsc --checkJs & cleanup fixes (for discussion)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /coverage
 package-lock.json
 /test/ts/**/*.js
+.*.swp
 
 # Additional bundles
 /devtools.js

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "minified:main": "dist/preact.min.js",
   "types": "dist/preact.d.ts",
   "scripts": {
+    "checkjs": "tsc --allowJs --checkJs --noEmit --target ES6 src/*.js src/**/*.js",
     "clean": "rimraf dist/ devtools.js devtools.js.map debug.js debug.js.map test/ts/**/*.js",
     "copy-flow-definition": "copyfiles -f src/preact.js.flow dist",
     "copy-typescript-definition": "copyfiles -f src/preact.d.ts dist",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "sinon": "^4.4.2",
     "sinon-chai": "^3.0.0",
-    "typescript": "^2.9.0-rc",
+    "typescript": "^2.9.2",
     "uglify-js": "^2.7.5",
     "webpack": "^4.3.0"
   },

--- a/src/clone-element.js
+++ b/src/clone-element.js
@@ -2,11 +2,15 @@ import { extend } from './util';
 import { h } from './h';
 
 /**
+ * @typedef {import('./vnode').VNode} VNode
+ */
+
+/**
  * Clones the given VNode, optionally adding attributes/props and replacing its
  * children.
- * @param {import('./vnode').VNode} vnode The virtual DOM element to clone
+ * @param {VNode} vnode The virtual DOM element to clone
  * @param {object} props Attributes/props to add when cloning
- * @param {Array<import('./vnode').VNode>} [rest] Any additional arguments will be used as replacement
+ * @param {Array<VNode>} [rest] Any additional arguments will be used as replacement
  *  children.
  */
 export function cloneElement(vnode, props) {

--- a/src/render-queue.js
+++ b/src/render-queue.js
@@ -3,14 +3,18 @@ import { defer } from './util';
 import { renderComponent } from './vdom/component';
 
 /**
+ * @typedef {import('./component').Component} Component
+ */
+
+/**
  * Managed queue of dirty components to be re-rendered
- * @type {Array<import('./component').Component>}
+ * @type {Array<Component>}
  */
 let items = [];
 
 /**
  * Enqueue a rerender of a component
- * @param {import('./component').Component} component The component to rerender
+ * @param {Component} component The component to rerender
  */
 export function enqueueRender(component) {
 	if (!component._dirty && (component._dirty = true) && items.push(component)==1) {

--- a/src/render.js
+++ b/src/render.js
@@ -1,10 +1,14 @@
 import { diff } from './vdom/diff';
 
 /**
+ * @typedef {import('./dom/index.js').PreactElement} PreactElement
+ */
+
+/**
  * Render JSX into a `parent` Element.
  * @param {import('./vnode').VNode} vnode A (JSX) VNode to render
- * @param {import('./dom').PreactElement} parent DOM element to render into
- * @param {import('./dom').PreactElement} [merge] Attempt to re-use an existing DOM tree rooted at
+ * @param {PreactElement} parent DOM element to render into
+ * @param {PreactElement} [merge] Attempt to re-use an existing DOM tree rooted at
  *  `merge`
  * @public
  *

--- a/src/render.js
+++ b/src/render.js
@@ -1,12 +1,13 @@
 import { diff } from './vdom/diff';
 
 /**
+ * @typedef {import('./vnode').VNode} VNode
  * @typedef {import('./dom/index.js').PreactElement} PreactElement
  */
 
 /**
  * Render JSX into a `parent` Element.
- * @param {import('./vnode').VNode} vnode A (JSX) VNode to render
+ * @param {VNode} vnode A (JSX) VNode to render
  * @param {PreactElement} parent DOM element to render into
  * @param {PreactElement} [merge] Attempt to re-use an existing DOM tree rooted at
  *  `merge`

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -8,6 +8,10 @@ import { createComponent, collectComponent } from './component-recycler';
 import { removeNode } from '../dom/index';
 
 /**
+ * @typedef {import('../dom/index.js').PreactElement} PreactElement
+ */
+
+/**
  * Set a component's `props` and possibly re-render the component
  * @param {import('../component').Component} component The Component to set props on
  * @param {object} props The new props
@@ -212,11 +216,11 @@ export function renderComponent(component, renderMode, mountAll, isChild) {
 
 /**
  * Apply the Component referenced by a VNode to the DOM.
- * @param {import('../dom').PreactElement} dom The DOM node to mutate
+ * @param {PreactElement} dom The DOM node to mutate
  * @param {import('../vnode').VNode} vnode A Component-referencing VNode
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
- * @returns {import('../dom').PreactElement} The created/mutated element
+ * @returns {PreactElement} The created/mutated element
  * @private
  */
 export function buildComponentFromVNode(dom, vnode, context, mountAll) {

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -8,12 +8,14 @@ import { createComponent, collectComponent } from './component-recycler';
 import { removeNode } from '../dom/index';
 
 /**
+ * @typedef {import('../component').Component} Component
  * @typedef {import('../dom/index.js').PreactElement} PreactElement
+ * @typedef {import('../vnode').VNode} VNode
  */
 
 /**
  * Set a component's `props` and possibly re-render the component
- * @param {import('../component').Component} component The Component to set props on
+ * @param {Component} component The Component to set props on
  * @param {object} props The new props
  * @param {number} renderMode Render options - specifies how to re-render the component
  * @param {object} context The new context
@@ -64,7 +66,7 @@ export function setComponentProps(component, props, renderMode, context, mountAl
 /**
  * Render a Component, triggering necessary lifecycle events and taking
  * High-Order Components into account.
- * @param {import('../component').Component} component The component to render
+ * @param {Component} component The component to render
  * @param {number} [renderMode] render mode, see constants.js for available options.
  * @param {boolean} [mountAll] Whether or not to immediately mount all components
  * @param {boolean} [isChild] ?
@@ -217,7 +219,7 @@ export function renderComponent(component, renderMode, mountAll, isChild) {
 /**
  * Apply the Component referenced by a VNode to the DOM.
  * @param {PreactElement} dom The DOM node to mutate
- * @param {import('../vnode').VNode} vnode A Component-referencing VNode
+ * @param {VNode} vnode A Component-referencing VNode
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
  * @returns {PreactElement} The created/mutated element
@@ -266,7 +268,7 @@ export function buildComponentFromVNode(dom, vnode, context, mountAll) {
 
 /**
  * Remove a component from the DOM and recycle it.
- * @param {import('../component').Component} component The Component instance to unmount
+ * @param {Component} component The Component instance to unmount
  * @private
  */
 export function unmountComponent(component) {

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -7,12 +7,14 @@ import options from '../options';
 import { removeNode } from '../dom/index';
 
 /**
+ * @typedef {import('../component').Component} Component
  * @typedef {import('../dom/index.js').PreactElement} PreactElement
+ * @typedef {import('../vnode').VNode} VNode
  */
 
 /**
  * Queue of components that have been mounted and are awaiting componentDidMount
- * @type {Array<import('../component').Component>}
+ * @type {Array<Component>}
  */
 export const mounts = [];
 
@@ -38,7 +40,7 @@ export function flushMounts() {
 /**
  * Apply differences in a given vnode (and it's deep children) to a real DOM Node.
  * @param {PreactElement} dom A DOM node to mutate into the shape of a `vnode`
- * @param {import('../vnode').VNode} vnode A VNode (with descendants forming a tree) representing
+ * @param {VNode} vnode A VNode (with descendants forming a tree) representing
  *  the desired DOM structure
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
@@ -78,7 +80,7 @@ export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
 /**
  * Internals of `diff()`, separated to allow bypassing diffLevel / mount flushing.
  * @param {PreactElement} dom A DOM node to mutate into the shape of a `vnode`
- * @param {import('../vnode').VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
+ * @param {VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
  * @param {boolean} [componentRoot] ?
@@ -166,7 +168,7 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 	// otherwise, if there are existing or new children, diff them:
 	else if (vchildren && vchildren.length || fc!=null) {
 		innerDiffNode(out,
-			/** @type {import('../vnode').VNode[]} */(vchildren),
+			/** @type {VNode[]} */(vchildren),
 			context, mountAll, hydrating || props.dangerouslySetInnerHTML!=null);
 	}
 
@@ -185,7 +187,7 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 /**
  * Apply child and attribute changes between a VNode and a DOM Node to the DOM.
  * @param {PreactElement} dom Element whose children should be compared & mutated
- * @param {Array<import('../vnode').VNode>} vchildren Array of VNodes to compare to `dom.childNodes`
+ * @param {Array<VNode>} vchildren Array of VNodes to compare to `dom.childNodes`
  * @param {object} context Implicitly descendant context object (from most
  *  recent `getChildContext()`)
  * @param {boolean} mountAll Whether or not to immediately mount all components

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -7,6 +7,10 @@ import options from '../options';
 import { removeNode } from '../dom/index';
 
 /**
+ * @typedef {import('../dom/index.js').PreactElement} PreactElement
+ */
+
+/**
  * Queue of components that have been mounted and are awaiting componentDidMount
  * @type {Array<import('../component').Component>}
  */
@@ -33,14 +37,14 @@ export function flushMounts() {
 
 /**
  * Apply differences in a given vnode (and it's deep children) to a real DOM Node.
- * @param {import('../dom').PreactElement} dom A DOM node to mutate into the shape of a `vnode`
+ * @param {PreactElement} dom A DOM node to mutate into the shape of a `vnode`
  * @param {import('../vnode').VNode} vnode A VNode (with descendants forming a tree) representing
  *  the desired DOM structure
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
  * @param {Element} parent ?
  * @param {boolean} componentRoot ?
- * @returns {import('../dom').PreactElement} The created/mutated element
+ * @returns {PreactElement} The created/mutated element
  * @private
  */
 export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
@@ -71,7 +75,7 @@ export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
 
 /**
  * Internals of `diff()`, separated to allow bypassing diffLevel / mount flushing.
- * @param {import('../dom').PreactElement} dom A DOM node to mutate into the shape of a `vnode`
+ * @param {PreactElement} dom A DOM node to mutate into the shape of a `vnode`
  * @param {import('../vnode').VNode} vnode A VNode (with descendants forming a tree) representing the desired DOM structure
  * @param {object} context The current context
  * @param {boolean} mountAll Whether or not to immediately mount all components
@@ -174,7 +178,7 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 
 /**
  * Apply child and attribute changes between a VNode and a DOM Node to the DOM.
- * @param {import('../dom').PreactElement} dom Element whose children should be compared & mutated
+ * @param {PreactElement} dom Element whose children should be compared & mutated
  * @param {Array<import('../vnode').VNode>} vchildren Array of VNodes to compare to `dom.childNodes`
  * @param {object} context Implicitly descendant context object (from most
  *  recent `getChildContext()`)
@@ -270,7 +274,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 
 /**
  * Recursively recycle (or just unmount) a node and its descendants.
- * @param {import('../dom').PreactElement} node DOM node to start
+ * @param {PreactElement} node DOM node to start
  *  unmount/removal from
  * @param {boolean} [unmountOnly=false] If `true`, only triggers unmount
  *  lifecycle, skips removal
@@ -312,7 +316,7 @@ export function removeChildren(node) {
 
 /**
  * Apply differences in attributes from a VNode to the given DOM Element.
- * @param {import('../dom').PreactElement} dom Element with attributes to diff `attrs` against
+ * @param {PreactElement} dom Element with attributes to diff `attrs` against
  * @param {object} attrs The desired end-state key-value attribute pairs
  * @param {object} old Current/previous attributes (from previous VNode or
  *  element's prop cache)

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -51,7 +51,9 @@ export function diff(dom, vnode, context, mountAll, parent, componentRoot) {
 	// diffLevel having been 0 here indicates initial entry into the diff (not a subdiff)
 	if (!diffLevel++) {
 		// when first starting the diff, check if we're diffing an SVG or within an SVG
-		isSvgMode = parent != null && /** @type{SVGElement} */(parent).ownerSVGElement!==undefined;
+		isSvgMode =
+			parent != null &&
+			/** @type{SVGElement} */(parent).ownerSVGElement !== undefined;
 
 		// hydration is indicated by the existing element to be diffed not having a prop cache
 		hydrating = dom!=null && !(ATTR_KEY in dom);
@@ -87,7 +89,8 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 		prevSvgMode = isSvgMode;
 
 	// empty values (null, undefined, booleans) render as empty Text nodes
-	if (vnode == null || typeof vnode === 'boolean') /** @type {any} */(vnode) = '';
+	if (vnode == null || typeof vnode === 'boolean')
+		/** @type {any} */(vnode) = '';
 
 
 	// Fast case: Strings & Numbers create/update Text nodes.
@@ -156,12 +159,15 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 	// Optimization: fast-path for elements containing a single TextNode:
 	if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc!=null && fc['splitText']!==undefined && fc.nextSibling==null) {
 		if (fc.nodeValue!=vchildren[0]) {
-			fc.nodeValue = /** @type {string} */(vchildren[0]);
+			fc.nodeValue =
+				/** @type {string} */(vchildren[0]);
 		}
 	}
 	// otherwise, if there are existing or new children, diff them:
 	else if (vchildren && vchildren.length || fc!=null) {
-		innerDiffNode(out, /** @type {import('../vnode').VNode[]} */(vchildren), context, mountAll, hydrating || props.dangerouslySetInnerHTML!=null);
+		innerDiffNode(out,
+			/** @type {import('../vnode').VNode[]} */(vchildren),
+			context, mountAll, hydrating || props.dangerouslySetInnerHTML!=null);
 	}
 
 
@@ -230,7 +236,8 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 			// attempt to pluck a node of the same type from the existing children
 			else if (min<childrenLen) {
 				for (j=min; j<childrenLen; j++) {
-					if (children[j] !== undefined && isSameNodeType(c = /** @type {any[]} */(children)[j], vchild, isHydrating)) {
+					if (children[j] !== undefined &&
+							isSameNodeType(c = /** @type {any[]} */(children)[j], vchild, isHydrating)) {
 						child = c;
 						children[j] = undefined;
 						if (j===childrenLen-1) childrenLen--;
@@ -266,7 +273,8 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 
 	// remove orphaned unkeyed children:
 	while (min<=childrenLen) {
-		if ((child = children[childrenLen--]) !== undefined) recollectNodeTree(/** @type { any } */(child), false);
+		if ((child = children[childrenLen--]) !== undefined)
+			recollectNodeTree(/** @type { any } */(child), false);
 	}
 }
 

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -2,13 +2,14 @@ import { extend } from '../util';
 
 /**
  * @typedef {import('../dom/index.js').PreactElement} PreactElement
+ * @typedef {import('../vnode').VNode} VNode
  */
 
 
 /**
  * Check if two nodes are equivalent.
  * @param {PreactElement} node DOM Node to compare
- * @param {import('../vnode').VNode} vnode Virtual DOM node to compare
+ * @param {VNode} vnode Virtual DOM node to compare
  * @param {boolean} [hydrating=false] If true, ignores component constructors
  *  when comparing.
  * @private
@@ -38,7 +39,7 @@ export function isNamedNode(node, nodeName) {
  * Reconstruct Component-style `props` from a VNode.
  * Ensures default/fallback values from `defaultProps`:
  * Own-properties of `defaultProps` not present in `vnode.attributes` are added.
- * @param {import('../vnode').VNode} vnode The VNode to get props for
+ * @param {VNode} vnode The VNode to get props for
  * @returns {object} The props to use for this VNode
  */
 export function getNodeProps(vnode) {

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -1,9 +1,13 @@
 import { extend } from '../util';
 
+/**
+ * @typedef {import('../dom/index.js').PreactElement} PreactElement
+ */
+
 
 /**
  * Check if two nodes are equivalent.
- * @param {import('../dom').PreactElement} node DOM Node to compare
+ * @param {PreactElement} node DOM Node to compare
  * @param {import('../vnode').VNode} vnode Virtual DOM node to compare
  * @param {boolean} [hydrating=false] If true, ignores component constructors
  *  when comparing.
@@ -22,7 +26,7 @@ export function isSameNodeType(node, vnode, hydrating) {
 
 /**
  * Check if an Element has a given nodeName, case-insensitively.
- * @param {import('../dom').PreactElement} node A DOM Element to inspect the name of.
+ * @param {PreactElement} node A DOM Element to inspect the name of.
  * @param {string} nodeName Unnormalized name to compare against.
  */
 export function isNamedNode(node, nodeName) {


### PR DESCRIPTION
Changes on top of developit/preact#1161:
- JSDoc fixes for `PreactElement` to pass the following check: `tsc --allowJs --checkJs --noEmit --target ES6 src/*.js src/**/*.js`
- add `checkjs` script to run the tsc checkJs command automatically (maybe should have used camelCase for the script name)
- minor cleanup of what I think are some not-so-pretty JSDoc updates to `src/vdom/diff.js`
- separate import for other JSDoc `@param` items (extra cleanup)
- other minor updates:
  - update to typescript@^2.9.2
  - .gitignore fix for .*.swp

The following tests seem to succeed for me with these changes:
- `npm run eslint`
- `npm run checkjs`
- `npm run build`
- `npm t` (short for `npm test`)

I am calling this "experimental" since my experience with both TypeScript and Preact is extremely limited at this point.

Please feel free rework these changes if needed and include with developit/preact#1161 as you feel is appropriate.

Other ideas to take a look at someday (not sure if done already):
- checkJs on test
- (semi)standard
- prettify