### PR TITLE
More checkJs & JSDoc fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "minified:main": "dist/preact.min.js",
   "types": "dist/preact.d.ts",
   "scripts": {
-    "checkjs": "tsc --allowJs --checkJs --noEmit --target ES6 src/*.js src/**/*.js",
+    "checkJs": "tsc --allowJs --checkJs --noEmit --target ES6 src/*.js src/**/*.js",
     "clean": "rimraf dist/ devtools.js devtools.js.map debug.js debug.js.map test/ts/**/*.js",
     "copy-flow-definition": "copyfiles -f src/preact.js.flow dist",
     "copy-typescript-definition": "copyfiles -f src/preact.d.ts dist",

--- a/src/component.js
+++ b/src/component.js
@@ -2,6 +2,11 @@ import { FORCE_RENDER } from './constants';
 import { extend } from './util';
 import { renderComponent } from './vdom/component';
 import { enqueueRender } from './render-queue';
+
+/**
+ * @typedef {import('./vnode').VNode} VNode
+ */
+
 /**
  * Base Component class.
  * Provides `setState()` and `forceUpdate()`, which trigger rendering.
@@ -79,7 +84,7 @@ extend(Component.prototype, {
 	 * @param {object} state The component's current state
 	 * @param {object} context Context object, as returned by the nearest
 	 *  ancestor's `getChildContext()`
-	 * @returns {import('./vnode').VNode | void}
+	 * @returns {VNode | void}
 	 */
 	render() {}
 

--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -26,7 +26,7 @@ export function collectComponent(component) {
  * @param {(props, context) => void} Ctor The constructor of the component to create
  * @param {object} props The initial props of the component
  * @param {object} context The initial context of the component
- * @returns {import('../component').Component}
+ * @returns {Component}
  */
 export function createComponent(Ctor, props, context) {
 	let list = components[Ctor.name],

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -246,7 +246,10 @@ export function buildComponentFromVNode(dom, vnode, context, mountAll) {
 			dom = oldDom = null;
 		}
 
-		c = createComponent(/** @type {function} */(vnode.nodeName), props, context);
+		const f =
+			/** @type {(props, context) => void} */(vnode.nodeName);
+
+		c = createComponent(f, props, context);
 		if (dom && !c.nextBase) {
 			c.nextBase = dom;
 			// passing dom/oldDom as nextBase will recycle it if unused, so bypass recycling on L229:

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -162,15 +162,17 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 
 	// Optimization: fast-path for elements containing a single TextNode:
 	if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc!=null && fc['splitText']!==undefined && fc.nextSibling==null) {
-		if (fc.nodeValue!=vchildren[0]) {
-			fc.nodeValue =
-				/** @type {string} */(vchildren[0]);
+		const vchild =
+			/** @type {string} */(vchildren[0]);
+		if (fc.nodeValue!=vchild) {
+			fc.nodeValue = vchild;
 		}
 	}
 	// otherwise, if there are existing or new children, diff them:
 	else if (vchildren && vchildren.length || fc!=null) {
-		innerDiffNode(out,
-			/** @type {VNode[]} */(vchildren),
+		const vnodeChildren =
+			/** @type {VNode[]} */(vchildren);
+		innerDiffNode(out, vnodeChildren,
 			context, mountAll, hydrating || props.dangerouslySetInnerHTML!=null);
 	}
 
@@ -205,7 +207,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 		len = originalChildren.length,
 		childrenLen = 0,
 		vlen = vchildren ? vchildren.length : 0,
-		j, c, f, vchild, child;
+		j, f, vchild, child;
 
 	// Build up a map of keyed children and an Array of unkeyed children:
 	if (len!==0) {
@@ -240,8 +242,9 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 			// attempt to pluck a node of the same type from the existing children
 			else if (min<childrenLen) {
 				for (j=min; j<childrenLen; j++) {
-					if (children[j] !== undefined &&
-							isSameNodeType(c = /** @type {any[]} */(children)[j], vchild, isHydrating)) {
+					const c =
+						/** @type {any[]} */(children)[j];
+					if (c !== undefined && isSameNodeType(c, vchild, isHydrating)) {
 						child = c;
 						children[j] = undefined;
 						if (j===childrenLen-1) childrenLen--;
@@ -277,8 +280,10 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 
 	// remove orphaned unkeyed children:
 	while (min<=childrenLen) {
-		if ((child = children[childrenLen--]) !== undefined)
-			recollectNodeTree(/** @type { any } */(child), false);
+		const c =
+			/** @type { any } */(children[childrenLen--]);
+		if (c !== undefined)
+			recollectNodeTree(c, false);
 	}
 }
 

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -107,7 +107,9 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 		}
 		else {
 			// it wasn't a Text node: replace it with one and recycle the old Element
-			/** @type {any} */(out) = document.createTextNode(vnode);
+			/** @type {any} */(out) =
+				document.createTextNode(vnode);
+
 			if (dom) {
 				if (dom.parentNode) dom.parentNode.replaceChild(out, dom);
 				recollectNodeTree(dom, true);


### PR DESCRIPTION
__changes:__
- _Fix JSDoc cast in buildComponentFromVNode, using separate const_
- Use internal consts to cleanup inline JSDoc typings
- JSDoc import fixes that I missed in rbiggs/preact#1
- camelCase checkJs script name in package.json
- remove an internal `isSvgMode` computation that is never used
- other minor cleanup items

Tested as follows:
- `npm run lint && npm run checkJs` passes
- `npm run build && npm t` passes