### PR TITLE
Additional checkJS / JSDoc fixes

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -2,6 +2,10 @@ import { IS_NON_DIMENSIONAL } from '../constants';
 import options from '../options';
 
 /**
+ * @typedef {import('../component').Component} Component
+ */
+
+/**
  * A DOM event listener
  * @typedef {(e: Event) => void} EventListener
  */
@@ -17,7 +21,7 @@ import options from '../options';
  * @property {string} [normalizedNodeName] A normalized node name to use in diffing
  * @property {string} [splitText]
  * @property {EventListenerMap} [_listeners] A map of event listeners added by components to this DOM node
- * @property {import('../component').Component} [_component] The component that rendered this DOM node
+ * @property {Component} [_component] The component that rendered this DOM node
  * @property {function} [_componentConstructor] The constructor of the component that rendered this DOM node
  */
 

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -15,6 +15,7 @@ import options from '../options';
  * Properties Preact adds to elements it creates
  * @typedef PreactElementExtensions
  * @property {string} [normalizedNodeName] A normalized node name to use in diffing
+ * @property {string} [splitText]
  * @property {EventListenerMap} [_listeners] A map of event listeners added by components to this DOM node
  * @property {import('../component').Component} [_component] The component that rendered this DOM node
  * @property {function} [_componentConstructor] The constructor of the component that rendered this DOM node

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -3,7 +3,7 @@ import options from '../options';
 
 /**
  * A DOM event listener
- * @typedef {(e: Event) => void} EventListner
+ * @typedef {(e: Event) => void} EventListener
  */
 
 /**

--- a/src/vdom/component-recycler.js
+++ b/src/vdom/component-recycler.js
@@ -19,6 +19,10 @@ export function collectComponent(component) {
 	(components[name] || (components[name] = [])).push(component);
 }
 
+/**
+ * @typedef {Component} CustomComponent
+ * @property {function} render
+ */
 
 /**
  * Create a component. Normalizes differences between PFC's and classful
@@ -39,7 +43,8 @@ export function createComponent(Ctor, props, context) {
 	else {
 		inst = new Component(props, context);
 		inst.constructor = Ctor;
-		inst['render'] = doRender;
+		/** @type {CustomComponent} */(inst).render =
+			doRender;
 	}
 
 

--- a/src/vdom/component.js
+++ b/src/vdom/component.js
@@ -246,10 +246,10 @@ export function buildComponentFromVNode(dom, vnode, context, mountAll) {
 			dom = oldDom = null;
 		}
 
-		const f =
-			/** @type {(props, context) => void} */(vnode.nodeName);
+		c = createComponent(
+			/** @type {(props, context) => void} */(vnode.nodeName),
+			props, context);
 
-		c = createComponent(f, props, context);
 		if (dom && !c.nextBase) {
 			c.nextBase = dom;
 			// passing dom/oldDom as nextBase will recycle it if unused, so bypass recycling on L229:

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -151,13 +151,13 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 	}
 
 
-	/**
-	 * @type {object}
-	 * @property {string} [splitText]
-	 */
-	const fc = out.firstChild;
-
-	let props = out[ATTR_KEY],
+	let fc =
+		/**
+		 * @type {object}
+		 * @property {string} [splitText]
+		 */
+		(out.firstChild),
+		props = out[ATTR_KEY],
 		vchildren = vnode.children;
 
 	if (props==null) {
@@ -212,16 +212,16 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 		len = originalChildren.length,
 		childrenLen = 0,
 		vlen = vchildren ? vchildren.length : 0,
-		j, f, vchild, child;
+		j, c, f, vchild, child;
 
 	// Build up a map of keyed children and an Array of unkeyed children:
 	if (len!==0) {
 		for (let i=0; i<len; i++) {
-			/** @type{object} */
-			const child = originalChildren[i];
+			const child =
+				/** @type{object} */(originalChildren[i]),
+				props = child[ATTR_KEY],
+				key = vlen && props ? child._component ? child._component.__key : props.key : null;
 
-			const props = child[ATTR_KEY];
-			const key = vlen && props ? child._component ? child._component.__key : props.key : null;
 			if (key!=null) {
 				keyedLen++;
 				keyed[key] = child;
@@ -249,8 +249,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 			// attempt to pluck a node of the same type from the existing children
 			else if (min<childrenLen) {
 				for (j=min; j<childrenLen; j++) {
-					const c = (children)[j];
-					if (c !== undefined && isSameNodeType(c, vchild, isHydrating)) {
+					if (children[j]!==undefined && isSameNodeType(c = children[j], vchild, isHydrating)) {
 						child = c;
 						children[j] = undefined;
 						if (j===childrenLen-1) childrenLen--;
@@ -286,9 +285,8 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 
 	// remove orphaned unkeyed children:
 	while (min<=childrenLen) {
-		const c = children[childrenLen--];
-		if (c !== undefined)
-			recollectNodeTree(c, false);
+		if ((child = children[childrenLen--])!==undefined)
+			recollectNodeTree(child, false);
 	}
 }
 

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -99,7 +99,7 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 	if (typeof vnode==='string' || typeof vnode==='number') {
 
 		// update if it's already a Text node:
-		if (dom && dom['splitText']!==undefined && dom.parentNode && (!dom._component || componentRoot)) {
+		if (dom && dom.splitText !== undefined && dom.parentNode && (!dom._component || componentRoot)) {
 			/* istanbul ignore if */ /* Browser quirk that can't be covered: https://github.com/developit/preact/commit/fd4f21f5c45dfd75151bd27b4c217d8003aa5eb9 */
 			if (dom.nodeValue!=vnode) {
 				dom.nodeValue = vnode;
@@ -151,8 +151,13 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 	}
 
 
-	let fc = out.firstChild,
-		props = out[ATTR_KEY],
+	/**
+	 * @type {object}
+	 * @property {string} [splitText]
+	 */
+	const fc = out.firstChild;
+
+	let props = out[ATTR_KEY],
 		vchildren = vnode.children;
 
 	if (props==null) {
@@ -161,7 +166,7 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 	}
 
 	// Optimization: fast-path for elements containing a single TextNode:
-	if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc!=null && fc['splitText']!==undefined && fc.nextSibling==null) {
+	if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc!=null && fc.splitText!==undefined && fc.nextSibling==null) {
 		const vchild =
 			/** @type {string} */(vchildren[0]);
 		if (fc.nodeValue!=vchild) {
@@ -212,14 +217,16 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 	// Build up a map of keyed children and an Array of unkeyed children:
 	if (len!==0) {
 		for (let i=0; i<len; i++) {
-			let child = originalChildren[i],
-				props = child[ATTR_KEY],
-				key = vlen && props ? child['_component'] ? child['_component'].__key : props.key : null;
+			/** @type{object} */
+			const child = originalChildren[i];
+
+			const props = child[ATTR_KEY];
+			const key = vlen && props ? child._component ? child._component.__key : props.key : null;
 			if (key!=null) {
 				keyedLen++;
 				keyed[key] = child;
 			}
-			else if (props || (child['splitText']!==undefined ? (isHydrating ? child.nodeValue.trim() : true) : isHydrating)) {
+			else if (props || (child.splitText !== undefined ? (isHydrating ? child.nodeValue.trim() : true) : isHydrating)) {
 				children[childrenLen++] = child;
 			}
 		}

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -249,8 +249,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 			// attempt to pluck a node of the same type from the existing children
 			else if (min<childrenLen) {
 				for (j=min; j<childrenLen; j++) {
-					const c =
-						/** @type {any[]} */(children)[j];
+					const c = (children)[j];
 					if (c !== undefined && isSameNodeType(c, vchild, isHydrating)) {
 						child = c;
 						children[j] = undefined;
@@ -287,8 +286,7 @@ function innerDiffNode(dom, vchildren, context, mountAll, isHydrating) {
 
 	// remove orphaned unkeyed children:
 	while (min<=childrenLen) {
-		const c =
-			/** @type { any } */(children[childrenLen--]);
+		const c = children[childrenLen--];
 		if (c !== undefined)
 			recollectNodeTree(c, false);
 	}

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -167,18 +167,18 @@ function idiff(dom, vnode, context, mountAll, componentRoot) {
 
 	// Optimization: fast-path for elements containing a single TextNode:
 	if (!hydrating && vchildren && vchildren.length===1 && typeof vchildren[0]==='string' && fc!=null && fc.splitText!==undefined && fc.nextSibling==null) {
-		const vchild =
-			/** @type {string} */(vchildren[0]);
-		if (fc.nodeValue!=vchild) {
-			fc.nodeValue = vchild;
+		if (fc.nodeValue != vchildren[0]) {
+			fc.nodeValue =
+				/** @type {string} */(vchildren[0]);
 		}
 	}
 	// otherwise, if there are existing or new children, diff them:
 	else if (vchildren && vchildren.length || fc!=null) {
-		const vnodeChildren =
-			/** @type {VNode[]} */(vchildren);
-		innerDiffNode(out, vnodeChildren,
-			context, mountAll, hydrating || props.dangerouslySetInnerHTML!=null);
+		innerDiffNode(out,
+			/** @type {VNode[]} */(vchildren),
+			context,
+			mountAll,
+			hydrating || props.dangerouslySetInnerHTML!=null);
 	}
 
 

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -16,7 +16,7 @@ import { extend } from '../util';
  */
 export function isSameNodeType(node, vnode, hydrating) {
 	if (typeof vnode==='string' || typeof vnode==='number') {
-		return node['splitText']!==undefined;
+		return node.splitText !== undefined;
 	}
 	if (typeof vnode.nodeName==='string') {
 		return !node._componentConstructor && isNamedNode(node, vnode.nodeName);
@@ -46,7 +46,13 @@ export function getNodeProps(vnode) {
 	let props = extend({}, vnode.attributes);
 	props.children = vnode.children;
 
-	let defaultProps = vnode.nodeName['defaultProps'];
+	let defaultProps =
+		/**
+		 * @type {object}
+		 * @property {any} defaultProps
+		 */
+		(vnode.nodeName).defaultProps;
+
 	if (defaultProps!==undefined) {
 		for (let i in defaultProps) {
 			if (props[i]===undefined) {

--- a/src/vdom/index.js
+++ b/src/vdom/index.js
@@ -40,7 +40,7 @@ export function isNamedNode(node, nodeName) {
  * Ensures default/fallback values from `defaultProps`:
  * Own-properties of `defaultProps` not present in `vnode.attributes` are added.
  * @param {VNode} vnode The VNode to get props for
- * @returns {object} The props to use for this VNode
+ * @returns {Object.<string, any>} The props to use for this VNode
  */
 export function getNodeProps(vnode) {
 	let props = extend({}, vnode.attributes);

--- a/src/vnode.js
+++ b/src/vnode.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-// Prevent warning of using VNode before declaration in defnition of children property.
 /**
  * Virtual DOM Node
  * @typedef VNode


### PR DESCRIPTION
- Use JSDoc types to eliminate need for expando property strings
- inline some of the const declarations to reduce size as requested in <https://github.com/developit/preact/pull/1161#issuecomment-406824549>
- _transform JSDoc `any` -> `object` where possible (in 2 places)_
- other minor fixes

Tested as follows:

- `npm run lint && npm run checkJs` passes
- `npm run build && npm t` passes
- Size of `dist/preact.js` and `dist/preact.min.js` is much closer to the size before changes proposed in rbiggs/preact#1 & rbiggs/preact#2